### PR TITLE
Fix build warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS = -Wall -std=c99
+CFLAGS = -Wall -std=gnu99
 LDFLAGS = -lpthread
 
 all: me

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ LDFLAGS = -lpthread
 
 all: me
 me: me.c
-	$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS)	
+	$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS)
 
 clean:
 	$(RM) me


### PR DESCRIPTION
Hi,

When I try to build me, I meet the warning of implicit declaration of function strdup, usleep, ftruncate and getline.

Fix it by using gnu99.

In addition, I also remove a redundant space.

Thanks.