### PR TITLE
Use binary units for file size display

### DIFF
--- a/me.c
+++ b/me.c
@@ -660,8 +660,8 @@ void save_file()
             close(fd);
             free(buf);
             ec.modified = 0;
-            if (len > 1000)
-                set_status_message("%d KB written to disk", len / 1000);
+            if (len >= 1024)
+                set_status_message("%d KiB written to disk", len >> 10);
             else
                 set_status_message("%d B written to disk", len);
             return;


### PR DESCRIPTION
Display file size using binary units (1024 bytes per KiB) instead of decimal units (1000 bytes per KB) to ensure accuracy. Optimize the size calculation using bitwise operations for improved performance.