### PR TITLE
realloc leak fixed

### DIFF
--- a/me.c
+++ b/me.c
@@ -940,12 +940,13 @@ char *prompt(char *msg, void (*callback)(char *, int))
         } else if (!iscntrl(c) && isprint(c)) {
             if (buf_len == buf_size - 1) {
                 buf_size *= 2;
-                char *new_buf = realloc(buf, buf_size); //In case realloc fails
-                if(NULL == new_buf){
+                char *new_buf = realloc(buf, buf_size);  // In case realloc
+                                                         // fails
+                if (NULL == new_buf) {
                     free(buf);
                     return NULL;
                 }
-                buf=new_buf;
+                buf = new_buf;
             }
             buf[buf_len++] = c;
             buf[buf_len] = '\0';

--- a/me.c
+++ b/me.c
@@ -940,7 +940,12 @@ char *prompt(char *msg, void (*callback)(char *, int))
         } else if (!iscntrl(c) && isprint(c)) {
             if (buf_len == buf_size - 1) {
                 buf_size *= 2;
-                buf = realloc(buf, buf_size);
+                char *new_buf = realloc(buf, buf_size); //In case realloc fails
+                if(NULL == new_buf){
+                    free(buf);
+                    return NULL;
+                }
+                buf=new_buf;
             }
             buf[buf_len++] = c;
             buf[buf_len] = '\0';


### PR DESCRIPTION
When realloc fails, it returns NULL but does not free the original memory. If the result isn't assigned to a temporary variable and checked, the original pointer can be lost, causing a memory leak.

This patch replaces direct assignment with a safe pattern using a temporary new_buf. If realloc fails, the original buffer is freed and NULL is returned.