### PR TITLE
Fix illegal memory access while moving gap

### DIFF
--- a/me.c
+++ b/me.c
@@ -293,9 +293,9 @@ static void gap_move(gap_buffer_t *gb, size_t pos)
         gb->egap -= len;
         gb->gap -= len;
         memmove(gb->egap, gb->gap, len);
-    } else if (dest > gb->gap) {
+    } else if (dest > gb->egap) {
         /* Move gap forward - shift text backward */
-        size_t len = dest - gb->gap;
+        size_t len = dest - gb->egap;
         memmove(gb->gap, gb->egap, len);
         gb->gap += len;
         gb->egap += len;


### PR DESCRIPTION
When operations are: open new file -> insert one character -> arrow left -> insert one character ->
arrow right -> insert one character -> insert one character. Above cause segmentation fault for undo_clear_redo function executes undo_node_t *node = stack->current->next;

the source of problem:
gap_ptr return gb->egap+(pos-front_size) when pos is located at [text after gap]. As the result, dest in gap_move also points to [text after gap]. If computes len = dest - gap, will easily cause unecessay move for byte after ebuffer.

For example, if dest points to first byte of text after gap, and memory layout is [text before gap][gap][text after gap] -> [1 byte][64Kib-2][1 byte] then len = 64Kib-1. Causing illegal memory access after egap.

test:
this commit pass the test.